### PR TITLE
Update to latest Node.js LTS (v14)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 COPY LICENSE README.md /
 


### PR DESCRIPTION
Node.js v10 LTS end of support is approaching on 30 April 2021, so we should upgrade to v14.