### PR TITLE
Add support for building typings, using a different package manager, and specifying a custom build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,31 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - uses: flarum/action-build@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build_script: build             # npm run build
+          typings_script: build-typings   # npm run build-typings
+          package_manager: npm            # Use NPM, not Yarn
 ```
 
-### Only Build on Master
+## Options
+
+Here is a full list of options available using the `with` syntax:
+
+| Name              | Required | Description                                                                                      | Example                       | Default |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------ | ----------------------------- | ------- |
+| `github_token`    | Yes      | Your Actions GitHub token. The example value should work for this by default.                    | `${{ secrets.GITHUB_TOKEN }}` | None    |
+| `build_script`    | Yes      | The `package.json` script to run to build your extension JS.                                     | `build`                       | `build` |
+| `typings_script`  | No       | If defined, runs the script of this name in `package.json` to build typings for your extension.  | `build-typings`               | Unset   |
+| `package_manager` | No       | Either `yarn` or `npm`. Will install dependencies and build using the specified package manager. | `yarn`                        | `npm`   |
+
+### Assumptions
+
+Your Javascript must be in a `js` folder, similar to how Flarum core and Flarum's first-party extensions are laid out.
+
+If building typings, we assume that they are built to `js/dist-typings`, as set in the example `tsconfig.json` found on the [flarum-tsconfig](https://github.com/flarum/flarum-tsconfig).
+
+## Only Build on Master
 
 If you only want to run the workflow when commits are pushed to the `master` branch, change `on: push` to the following:
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ jobs:
       - uses: flarum/action-build@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          build_script: build             # npm run build
-          typings_script: build-typings   # npm run build-typings
-          package_manager: npm            # Use NPM, not Yarn
+          build_script: build # npm run build
+          typings_script: build-typings # npm run build-typings
+          package_manager: npm # Use NPM, not Yarn
+          js_path: ./js # JS located in `./js`
 ```
 
 ## Options
@@ -35,6 +36,7 @@ Here is a full list of options available using the `with` syntax:
 | `build_script`    | Yes      | The `package.json` script to run to build your extension JS.                                     | `build`                       | `build` |
 | `typings_script`  | No       | If defined, runs the script of this name in `package.json` to build typings for your extension.  | `build-typings`               | Unset   |
 | `package_manager` | No       | Either `yarn` or `npm`. Will install dependencies and build using the specified package manager. | `yarn`                        | `npm`   |
+| `js_path`         | No       | Path to your JS folder (where `package.json` is located) from the root of your repository.       | `./js`                        | `./js`  |
 
 ### Assumptions
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ if [ -z "$INPUT_BUILD_SCRIPT" ]; then
 fi
 
 if [ -z "$INPUT_PACKAGE_MANAGER" ]; then
-  INPUT_BUILD_SCRIPT = "npm"
+  INPUT_PACKAGE_MANAGER = "npm"
 fi
 
 # script

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,15 +10,23 @@ reset='\e[0;10m'
 trap 'log "$BASH_COMMAND"' DEBUG
 
 log() {
-    # ignore echo commands
-    if [[ $1 != echo* ]]; then
-        echo "##[command]$1"
-    fi
+  # ignore echo commands
+  if [[ $1 != echo* ]]; then
+    echo "##[command]$1"
+  fi
 }
 
-if [ -z "$GITHUB_TOKEN" ]; then
-    echo -e "\e[0;31mGITHUB_TOKEN is not set."
-    exit 1
+if [ -z "$INPUT_GITHUB_TOKEN" ]; then
+  echo -e "\e[0;31mGITHUB_TOKEN is not set."
+  exit 1
+fi
+
+if [ -z "$INPUT_BUILD_SCRIPT" ]; then
+  INPUT_BUILD_SCRIPT = "build"
+fi
+
+if [ -z "$INPUT_PACKAGE_MANAGER" ]; then
+  INPUT_BUILD_SCRIPT = "npm"
 fi
 
 # script
@@ -31,18 +39,31 @@ git config user.email 'bot@flarum.org'
 echo -e "$style - installing dependencies $reset"
 
 cd js || exit 1
-npm i -g npm@7.11.2
-npm ci
+
+npm i -g npm@^7
+
+if [[ "$INPUT_PACKAGE_MANAGER" == "npm" ]]; then
+  npm ci
+else
+  npm i -g yarn
+  yarn install --frozen-lockfile
+fi
 
 echo -e "$style - building JavaScript files $reset"
 
-npm run build
+# npm run xxx or yarn run xxx
+$INPUT_PACKAGE_MANAGER run $INPUT_BUILD_SCRIPT
+
+if [ -v INPUT_TYPINGS_SCRIPT ]; then
+  $INPUT_PACKAGE_MANAGER run $INPUT_TYPINGS_SCRIPT
+  git add dist-typings/* -f
+fi
 
 git add dist/* -f
 
 if [[ -z $(git status -uno --porcelain) ]]; then
-    echo -e "$style - nothing to commit $reset"
-    exit
+  echo -e "$style - nothing to commit $reset"
+  exit
 fi
 
 echo -e "$style - committing and pushing $reset"
@@ -52,16 +73,16 @@ git commit -m "Bundled output for commit $GITHUB_SHA [skip ci]"
 # no longer exit on error
 set +e
 
-OUT="$(git push https://"$GITHUB_ACTOR":"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git HEAD:"$GITHUB_REF" 2>&1 > /dev/null)"
+OUT="$(git push https://"$GITHUB_ACTOR":"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git HEAD:"$GITHUB_REF" 2>&1 >/dev/null)"
 
-if grep -q "the remote contains work that you do\|a pushed branch tip is behind its remote" <<< "$OUT"; then
-    echo -e "$style - HEAD is behind $reset"
-    exit
-elif grep -q "fatal:\|error:" <<< "$OUT"; then
-    echo -e "$style - error $reset"
-    echo "$OUT"
-    exit 1
+if grep -q "the remote contains work that you do\|a pushed branch tip is behind its remote" <<<"$OUT"; then
+  echo -e "$style - HEAD is behind $reset"
+  exit
+elif grep -q "fatal:\|error:" <<<"$OUT"; then
+  echo -e "$style - error $reset"
+  echo "$OUT"
+  exit 1
 else
-    echo -e "$style - success $reset"
-    echo "$OUT"
+  echo -e "$style - success $reset"
+  echo "$OUT"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,8 +75,11 @@ if [ -v INPUT_TYPINGS_SCRIPT ]; then
   set -e
 
   git add dist-typings/* -f
+
+  COMMIT_DESC="Includes transpiled JS/TS, and Typescript declaration files (typings)."
 else
   echo -e "$style - not building typings $reset"
+  COMMIT_DESC="Includes transpiled JS/TS."
 fi
 
 git add dist/* -f
@@ -88,7 +91,8 @@ fi
 
 echo -e "$style - committing and pushing $reset"
 
-git commit -m "Bundled output for commit $GITHUB_SHA [skip ci]"
+# Multiple `-m`s are treated as separate paragraphs by git.
+git commit -m "Bundled output for commit $GITHUB_SHA" -m "$COMMIT_DESC" -m "[skip ci]"
 
 # no longer exit on error
 set +e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ echo -e "$style - setting up git $reset"
 git config user.name 'flarum-bot'
 git config user.email 'bot@flarum.org'
 
-echo -e "$style - installing dependencies $reset"
+echo -e "$style - installing dependencies with $INPUT_PACKAGE_MANAGER $reset"
 
 cd js || exit 1
 
@@ -49,14 +49,23 @@ else
   yarn install --frozen-lockfile
 fi
 
-echo -e "$style - building JavaScript files $reset"
+echo -e "$style - building Javascript/Typescript files $reset"
 
-# npm run xxx or yarn run xxx
+# Equivalent to npm run xxx or yarn run xxx
 $INPUT_PACKAGE_MANAGER run $INPUT_BUILD_SCRIPT
 
+# Build and add typings to staged files
 if [ -v INPUT_TYPINGS_SCRIPT ]; then
+  echo -e "$style - building typings $reset"
+
+  # Typings build often has errors -- let's not exit if we have any issues
+  set +e
   $INPUT_PACKAGE_MANAGER run $INPUT_TYPINGS_SCRIPT
+  set -e
+
   git add dist-typings/* -f
+else
+  echo -e "$style - not building typings $reset"
 fi
 
 git add dist/* -f

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,13 @@ log() {
 }
 
 if [ -z "$INPUT_GITHUB_TOKEN" ]; then
-  echo -e "\e[0;31mGITHUB_TOKEN is not set."
-  exit 1
+  # Backwards compatibility with `env` options method
+  if [ -v GITHUB_TOKEN ]; then
+    $INPUT_GITHUB_TOKEN=$GITHUB_TOKEN
+  else
+    echo -e "\e[0;31mGITHUB_TOKEN is not set."
+    exit 1
+  fi
 fi
 
 if [ -z "$INPUT_BUILD_SCRIPT" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,10 @@ if [ -z "$INPUT_PACKAGE_MANAGER" ]; then
   INPUT_PACKAGE_MANAGER = "npm"
 fi
 
+if [ -z "$INPUT_JS_PATH" ]; then
+  INPUT_JS_PATH = "./js"
+fi
+
 # script
 
 echo -e "$style - setting up git $reset"
@@ -41,9 +45,11 @@ echo -e "$style - setting up git $reset"
 git config user.name 'flarum-bot'
 git config user.email 'bot@flarum.org'
 
-echo -e "$style - installing dependencies with $INPUT_PACKAGE_MANAGER $reset"
+echo -e "$style - entering JS path ($INPUT_JS_PATH) $reset"
 
-cd js || exit 1
+cd $INPUT_JS_PATH || exit 1
+
+echo -e "$style - installing dependencies with $INPUT_PACKAGE_MANAGER $reset"
 
 npm i -g npm@^7
 


### PR DESCRIPTION
## **This is a breaking change.**

...but I have added a backcompat layer, even though I really shouldn't have to.

----

I have shifted syntax to use `with` instead of `env`, as this is designed for parameters.

See README for new syntax. Core has been updated accordingly.

We **really** (like REALLY) should be using tags for our actions... this will break every repo this action is on.

Prerequisite of flarum/core#2856.