### PR TITLE
chore: bump Node Docker image to LTS 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 COPY LICENSE README.md /
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Switches build container to Node.js LTS 16, bringing it up to date.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

N/A