### PR TITLE
feat: add option to commit all file changes after build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Here is a full list of options available using the `with` syntax:
 | `package_manager` | No       | Either `yarn` or `npm` or `pnpm`. Will install dependencies and build using the specified package manager. | `yarn`                        | `npm`   |
 | `js_path`         | No       | Path to your JS folder (where `package.json` is located) from the root of your repository.       | `./js`                        | `./js`  |
 | `do_not_commit`   | No       | Set to `true` to NOT commit the built JS/Typings. Useful for validating JS source.               | `false`                       | `false` |
+| `commit_all_dirty`| No       | Set to `true` to commit all file changes, not just files in the dist JS directory.               | `false`                       | `false` |
 
 ### Assumptions
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ jobs:
           package_manager: npm # Use NPM, not Yarn
           js_path: ./js # JS located in `./js`
           do_not_commit: false # Commit built JS by default
+          commit_all_dirty: false
 ```
 
 ## Options

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,10 +99,10 @@ if [[ "$INPUT_DO_NOT_COMMIT" != "false" ]]; then
   echo -e "$style - DO_NOT_COMMIT is true, so we won't commit these changes $reset"
 else
   if [[ "$INPUT_COMMIT_ALL_DIRTY" != "false" ]]; then
-    git add . -f
-  else
-    git add dist/* -f
+    git add -A
   fi
+
+  git add dist/* -f
 
   if [[ -z $(git status -uno --porcelain) ]]; then
     echo -e "$style - nothing to commit $reset"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,10 @@ if [ -z "$INPUT_DO_NOT_COMMIT" ]; then
   INPUT_DO_NOT_COMMIT="false"
 fi
 
+if [ -z "$INPUT_COMMIT_ALL_DIRTY" ]; then
+  INPUT_COMMIT_ALL_DIRTY="false"
+fi
+
 # script
 
 echo -e "$style - setting up git $reset"
@@ -94,7 +98,11 @@ fi
 if [[ "$INPUT_DO_NOT_COMMIT" != "false" ]]; then
   echo -e "$style - DO_NOT_COMMIT is true, so we won't commit these changes $reset"
 else
-  git add dist/* -f
+  if [[ "$INPUT_COMMIT_ALL_DIRTY" != "false" ]]; then
+    git add . -f
+  else
+    git add dist/* -f
+  fi
 
   if [[ -z $(git status -uno --porcelain) ]]; then
     echo -e "$style - nothing to commit $reset"


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Add option to change workflow to commit and push all dirty files instead of only dist JS.

This is useful, for example, if an ext uses Webpack chunking instead of bundling a module within its dist JS, and then copies these files to the `assets` dir.

See example usage: https://github.com/FriendsOfFlarum/profile-image-crop/commit/02e2e524d3355495c4ed0915f342a7e7bf8e2565