### PR TITLE
feat: add test script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: build # npm run build
           build_typings_script: build-typings # npm run build-typings
+          test_script: test # npm run test
           package_manager: npm # Use NPM, not Yarn
           js_path: ./js # JS located in `./js`
           do_not_commit: false # Commit built JS by default
@@ -35,18 +36,19 @@ jobs:
 Here is a full list of options available using the `with` syntax:
 
 | Name                   | Required | Description                                                                                                             | Example                       | Default |
-|------------------------| -------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------- |
+|------------------------| -------- |-------------------------------------------------------------------------------------------------------------------------|-------------------------------| ------- |
 | `github_token`         | Yes      | Your Actions GitHub token. The example value should work for this by default.                                           | `${{ secrets.GITHUB_TOKEN }}` | None    |
 | `build_script`         | Yes      | The `package.json` script to run to build your extension JS.                                                            | `build`                       | `build` |
 | `build_typings_script` | No       | If defined, runs the script of this name in `package.json` to build typings for your extension.                         | `build-typings`               | Unset   |
 | `format_script`        | No       | If defined, runs the script of this name in `package.json` to check code formatting of your extension's JS.             | `format-check`                | Unset   |
 | `check_typings_script` | No       | If defined, runs the script of this name in `package.json` to typecheck your extension's TypeScript code.               | `check-typings`               | Unset   |
 | `type_coverage_script` | No       | If defined, runs the script of this name in `package.json` to assess type coverage in your extension's TypeScript code. | `check-typings-coverage`      | Unset   |
+| `test_script`          | No       | If defined, runs the script of this name in `package.json` to run the test suite.                                       | `test`                        | Unset   |
 | `package_manager`      | No       | Either `yarn` or `npm` or `pnpm`. Will install dependencies and build using the specified package manager.              | `yarn`                        | `npm`   |
 | `js_path`              | No       | Path to your JS folder (where `package.json` is located) from the root of your repository.                              | `./js`                        | `./js`  |
 | `do_not_commit`        | No       | Set to `true` to NOT commit the built JS/Typings. Useful for validating JS source.                                      | `false`                       | `false` |
 | `checks`               | No       | An array of strings, where each is a script that should be run before committing built js.                              | `false`                       | `false` |
-| `commit_all_dirty`     | No       | Set to `true` to commit all file changes, not just files in the dist JS directory.               | `false`                       | `false` |
+| `commit_all_dirty`     | No       | Set to `true` to commit all file changes, not just files in the dist JS directory.                                      | `false`                       | `false` |
 
 ### Assumptions
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   type_coverage_script:
     description: (If needed) The name of the package.json script to run to assess TypeScript type coverage
     required: false
+  test_script:
+    description: (If needed) The name of the package.json script to run to run your tests
+    required: false
   package_manager:
     description: Name of your JS package manager (either npm or yarn)
     default: 'npm'

--- a/src/jobs/runTestScript.ts
+++ b/src/jobs/runTestScript.ts
@@ -1,0 +1,21 @@
+import * as core from '@actions/core';
+
+import type JSPackageManagerInterop from '../helper/JSPackageManagerInterop';
+import { debugLog, log } from '../helper/log';
+import canRunScript from '../helper/canRunScript';
+
+/**
+ * Runs typings coverage script using the selected package manager, if the feature
+ * is enabled.
+ */
+export default async function runTestScript(packageManager: JSPackageManagerInterop, packageJson: any): Promise<void> {
+  const testScript = core.getInput('test_script');
+
+  if (!canRunScript(testScript, packageJson)) {
+    debugLog(`** [${packageJson.name || '-'}] Skipping test script`);
+    return;
+  }
+
+  log(`-- [${packageJson.name || '-'}] Running test script...`);
+  await packageManager.runPackageScript(testScript);
+}

--- a/src/runCiJobs.ts
+++ b/src/runCiJobs.ts
@@ -9,6 +9,7 @@ import runFormatCheckScript from './jobs/runFormatCheckScript';
 import commitChangesToGit from './jobs/commitChangesToGit';
 import runCheckTypingsScript from './jobs/runCheckTypingsScript';
 import runTypingCoverageScript from './jobs/runTypingCoverageScript';
+import runTestScript from "./jobs/runTestScript";
 
 type RunOptions = {
   noPrepare?: boolean;
@@ -53,6 +54,7 @@ export default async function runCiJobs(
   }
   if (!noPostBuildChecks) {
     await runCheckTypingsScript(pm, packageJson);
+    await runTestScript(pm, packageJson);
   }
   if (!noCommit) {
     await commitChangesToGit(jp);


### PR DESCRIPTION
**Changes proposed in this pull request:**
Allows running JS tests with the workflow, check flarum/framework#3678 for context

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
